### PR TITLE
removing return to lobby button

### DIFF
--- a/assets/js/showdown-game.jsx
+++ b/assets/js/showdown-game.jsx
@@ -108,11 +108,6 @@ class Showdown extends React.Component {
     render() {
         let finishScreen =  <div>
             <p>You {this.state.finished}!</p>
-            <p>
-                <a onClick={() => {
-                    this.endGame();
-                }} href="javascript:void(0)">Return to lobby</a>
-            </p>
         </div>;
 
         let waitingRoom = <div className="waiting-room">


### PR DESCRIPTION
If one user hits end after the other user has ended and joined a game with the same name as the original game, causes issues in front end state. Removing return to lobby button for now to avoid this issue.